### PR TITLE
:NORMAL: Feature/core view resolution

### DIFF
--- a/core/src/main/java/com/cube/fusion/core/resolver/ViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/core/resolver/ViewResolver.kt
@@ -1,0 +1,13 @@
+package com.cube.fusion.core.resolver
+
+import com.cube.fusion.core.model.Model
+
+/**
+ * Interface for resolving a view's class when parsing JSON data
+ *
+ * Created by JR Mitchell on 03/March/2022.
+ * Copyright ® 3SidedCube. All rights reserved.
+ */
+interface ViewResolver {
+	fun resolveView(): Class<out Model?>?
+}


### PR DESCRIPTION
### What?
- Added `ViewResolver` interface to the `core` library
- Promoted `LegacyDisplayPopulator` from an object to a class
- `LegacyDisplayPopulator` now takes a `Collection<ViewResolver>` as construction parameter and uses this to register the Jackson subtypes

### Why?
In the legacy library, this object took the mapped types directly from `ViewHelper.viewResolvers`.
However, these view resolvers also contained a method for getting `ViewHolder`s, and therefore are unsuitable for going in the core repo.
The solution here is to make this core `ViewResolver` interface, which only resolves to a view class, but can be extended in the Android UI lib to make the `ViewHelper.viewResolvers` behave as intended.
Then, when used in an app, `ViewHelper.viewResolvers` (or any other collection of resolvers) can be passed as a construction parameter.
