### PR TITLE
:NORMAL: Feature/jitpack setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ The Display Populator is responsible for transforming a link to a single page of
 The legacy implementation utilises [Retrofit](https://square.github.io/retrofit/) and [Gson](https://github.com/google/gson) to fetch pages from an API.
 
 ## Installation
-In order to utilise the core library in a project, add the following dependency to your `build.gradle` file:
+[JitPack](https://jitpack.io/) is used to provide the Fusion artifacts.
+In order to utilise the core library in a project, update your `settings.gradle` (or root project `build.gradle` on older projects) to include the Jitpack maven repository:
+```groovy
+    repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+    }
+```
+Then, add the following dependency to your `build.gradle` file:
 ```groovy
     implementation 'com.github.3sidedcube.Android-Fusion-Core:core:{versionCode}'
 ```
@@ -29,8 +37,7 @@ If you wish to utilise all modules in this repo, you can alternatively add the f
 ```groovy
     implementation 'com.github.3sidedcube:Android-Fusion-Core:{versionCode}'
 ```
-[JitPack](https://jitpack.io/) is used to provide the Fusion artifacts.
-As such, `{versionCode}` can be replaced with:
+As these builds are provided using Jitpack, `{versionCode}` can be replaced with:
 
 - A specific commit, e.g `1a2b3c4d5e`
 - A specific branch's latest build, e.g `feature~jitpack-setup-SNAPSHOT`

--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ The legacy implementation utilises [Retrofit](https://square.github.io/retrofit/
 ## Installation
 In order to utilise the core library in a project, add the following dependency to your `build.gradle` file:
 ```groovy
-    //TODO
+    implementation 'com.github.3sidedcube.Android-Fusion-Core:core:{versionCode}'
 ```
 To utilise the legacy display populator, add the following dependency:
 ```groovy
-    //TODO
+    implementation 'com.github.3sidedcube.Android-Fusion-Core:core:{versionCode}'
+```
+If you wish to utilise all modules in this repo, you can alternatively add the following dependency:
+```groovy
+    implementation 'com.github.3sidedcube:Android-Fusion-Core:{versionCode}'
 ```
 [JitPack](https://jitpack.io/) is used to provide the Fusion artifacts.
+As such, `{versionCode}` can be replaced with:
+
+- A specific commit, e.g `1a2b3c4d5e`
+- A specific branch's latest build, e.g `feature~jitpack-setup-SNAPSHOT`
+- A specific pre-release tag, e.g `1.0.0-rc1`
+- A specific release tag, e.g `1.0.0`
+
+It is recommended that you use this library at a specific release tag, to ensure that the library is in a stable state.
 
 ## Usage
 Demo apps for the usage of Fusion can be found in the other relevant modules.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then, add the following dependency to your `build.gradle` file:
 ```
 To utilise the legacy display populator, add the following dependency:
 ```groovy
-    implementation 'com.github.3sidedcube.Android-Fusion-Core:core:{versionCode}'
+    implementation 'com.github.3sidedcube.Android-Fusion-Core:populator-legacy:{versionCode}'
 ```
 If you wish to utilise all modules in this repo, you can alternatively add the following dependency:
 ```groovy

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ def thisOrJitpackVersion(requiredVersion) {
 }
 
 ext {
-	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
+	// Do not remove the call to thisOrJitpackVersion - this ensures that versions for all generated artifacts are aligned.
 	fusionLibVersion = thisOrJitpackVersion('0.0.1')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,29 @@ buildscript {
 	}
 }
 
+/**
+ * Gets the version of exported artifacts, ensuring that (if building a pre-release or release build with Jitpack) it matches this version
+ *
+ * @param requiredVersion the version that is required for this project
+ * @return the consistent required version identifier for exported artifacts
+ */
+def thisOrJitpackVersion(requiredVersion) {
+	if("$System.env.JITPACK".toString() == "true") {
+		def jitpackVersion = "$System.env.VERSION".toString()
+		if(jitpackVersion ==~ /\w?\d+\.\d+\.\d+(-\w+)?/)
+		{
+			// A pre-release or release version: change the lib version to match
+			return jitpackVersion
+		}
+	}
+	return requiredVersion
+}
+
+ext {
+	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
+	fusionLibVersion = thisOrJitpackVersion('0.0.1')
+}
+
 task clean(type: Delete) {
 	delete rootProject.buildDir
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,7 +40,7 @@ android {
 					// You can then customize attributes of the publication as shown below.
 					groupId = 'com.cube.fusion.core'
 					artifactId = 'core'
-					version = '0.0.1'
+					version = project.fusionLibVersion
 				}
 			}
 		}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'com.android.library'
 	id 'kotlin-android'
 	id 'kotlin-parcelize'
+	id 'maven-publish'
 }
 
 android {
@@ -26,6 +27,23 @@ android {
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_8
 		targetCompatibility JavaVersion.VERSION_1_8
+	}
+
+	afterEvaluate {
+		publishing {
+			publications {
+				// Creates a Maven publication called "release".
+				release(MavenPublication) {
+					// Applies the component for the release build variant.
+					from components.release
+
+					// You can then customize attributes of the publication as shown below.
+					groupId = 'com.cube.fusion.core'
+					artifactId = 'core'
+					version = '0.0.1'
+				}
+			}
+		}
 	}
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk11
+install:
+  - ./gradlew clean core:build populator:legacy:build publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk11
 install:
-  - ./gradlew clean core:build populator:legacy:build publishToMavenLocal
+  - ./gradlew clean core:build populator:build publishToMavenLocal

--- a/populator/legacy/build.gradle
+++ b/populator/legacy/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'com.android.library'
 	id 'kotlin-android'
+	id 'maven-publish'
 }
 
 android {
@@ -28,6 +29,23 @@ android {
 	}
 	kotlinOptions {
 		jvmTarget = '1.8'
+	}
+
+	afterEvaluate {
+		publishing {
+			publications {
+				// Creates a Maven publication called "release".
+				release(MavenPublication) {
+					// Applies the component for the release build variant.
+					from components.release
+
+					// You can then customize attributes of the publication as shown below.
+					groupId = 'com.cube.fusion.populator.legacy'
+					artifactId = 'populator-legacy'
+					version = '0.0.1'
+				}
+			}
+		}
 	}
 }
 

--- a/populator/legacy/build.gradle
+++ b/populator/legacy/build.gradle
@@ -42,7 +42,7 @@ android {
 					// You can then customize attributes of the publication as shown below.
 					groupId = 'com.cube.fusion.populator.legacy'
 					artifactId = 'populator-legacy'
-					version = '0.0.1'
+					version = project.fusionLibVersion
 				}
 			}
 		}


### PR DESCRIPTION
### What?
- Added relevant publishing setup to `build.gradle` for both modules
- Added `jitpack.yml` file for specifying tasks to run when building the library
- Updated `README.md` with more complete instructions for installing
- Added `thisOrJitpackVersion()` method and `fusionLibVersion` global property to root `build.gradle` to ensure consistent artifact versioning

### Why?
So that the library can be imported to projects with ease

### Testing
I tested this behaviour whilst setting up [the Fusion Android Ui library](https://github.com/3sidedcube/Android-Fusion-AndroidUi).
This lib was able to successfully import the core dependencies from the specified commit.