### PR TITLE
Feature/full model constructors

### DIFF
--- a/core/src/main/java/com/cube/fusion/core/model/Border.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Border.kt
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Border {
-	var strokeWidth: Float = 0f
+class Border(
+	var strokeWidth: Float = 0f,
 	var color: String? = null
-}
+)

--- a/core/src/main/java/com/cube/fusion/core/model/Font.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Font.kt
@@ -17,7 +17,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Font {
+class Font(
+	var name: String? = null,
+	var weight: Weight? = null,
+	var size: Float? = null
+) {
 	/**
 	 * Enum class representing different weights of font
 	 *
@@ -47,13 +51,4 @@ class Font {
 		@JsonProperty("italic")
 		ITALIC,
 	}
-
-	/// Name of the font, e.g. "Open Sans"
-	var name: String? = null
-
-	/// Weight of the font, e.g. "Regular"
-	var weight: Weight? = null
-
-	/// Size of the font in pt, e.g. 10
-	var size: Float? = null
 }

--- a/core/src/main/java/com/cube/fusion/core/model/ImageSource.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/ImageSource.kt
@@ -17,9 +17,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class ImageSource {
-	var url: String? = null
-	var id: String? = null
-	var permalink: String? = null
+class ImageSource(
+	var url: String? = null,
+	var id: String? = null,
+	var permalink: String? = null,
 	var apiUrl: String? = null
-}
+)

--- a/core/src/main/java/com/cube/fusion/core/model/Margin.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Margin.kt
@@ -17,11 +17,12 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Margin {
-	var left: Float = 0.0f
-	var top: Float = 0.0f
-	var right: Float = 0.0f
-	var bottom: Float = 0.0f
+class Margin(
+	val left: Float = 0.0f,
+	val top: Float = 0.0f,
+	val right: Float = 0.0f,
+	val bottom: Float = 0.0f
+) {
 
 	companion object {
 		/**
@@ -32,11 +33,11 @@ class Margin {
 		 *
 		 * @return an instance of [Margin] with zero margin
 		 */
-		fun zeroMargin() = Margin().apply {
-			left = 0f
-			top = 0f
-			right = 0f
+		fun zeroMargin() = Margin(
+			left = 0f,
+			top = 0f,
+			right = 0f,
 			bottom = 0f
-		}
+		)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/core/model/Padding.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Padding.kt
@@ -17,11 +17,12 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Padding {
-	var left: Float = 0.0f
-	var top: Float = 0.0f
-	var right: Float = 0.0f
-	var bottom: Float = 0.0f
+class Padding(
+	val left: Float = 0.0f,
+	val top: Float = 0.0f,
+	val right: Float = 0.0f,
+	val bottom: Float = 0.0f
+) {
 
 	companion object {
 		/**
@@ -32,11 +33,11 @@ class Padding {
 		 *
 		 * @return an instance of [Padding] with zero padding
 		 */
-		fun zeroPadding() = Padding().apply {
-			left = 0f
-			top = 0f
-			right = 0f
+		fun zeroPadding() = Padding(
+			left = 0f,
+			top = 0f,
+			right = 0f,
 			bottom = 0f
-		}
+		)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/core/model/Page.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Page.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -24,14 +25,12 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
-class Page : Parcelable {
-	val `class` = "Page"
-	val id: String = ""
-	val slug: String = ""
-	val title: String = ""
-
-	@JsonProperty("analytics_screen_view")
-	var analyticsScreenView: String? = null
+class Page(
+	val id: String = "",
+	val slug: String = "",
+	val title: String = "",
+	@field:JsonProperty("analytics_screen_view") var analyticsScreenView: String? = null,
 	var screen: Screen? = null
-
+) : Parcelable {
+	@IgnoredOnParcel val `class` = "Page"
 }

--- a/core/src/main/java/com/cube/fusion/core/model/Shadow.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Shadow.kt
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  * @property blur the target gaussian blur factor for the shadow, in density pixels (dp)
  * @property spread the distance that the shadow should spread from the edge of the view, in density pixels (dp)
  */
-class Shadow {
-	var color: String? = null
-	var alpha: Float = 1f
-	var x: Float = 0f
-	var y: Float = 0f
-	var blur: Float = 0f
-	var spread: Float = 0f
-}
+class Shadow(
+	val color: String? = null,
+	val alpha: Float = 1f,
+	val x: Float = 0f,
+	val y: Float = 0f,
+	val blur: Float = 0f,
+	val spread: Float = 0f
+)

--- a/core/src/main/java/com/cube/fusion/core/model/Size.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Size.kt
@@ -18,7 +18,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Size : Parcelable {
-	var width: Float = 0.0f
-	var height: Float = 0.0f
-}
+class Size (
+	val width: Float = 0.0f,
+	val height: Float = 0.0f
+) : Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/UrlLink.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/UrlLink.kt
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class UrlLink {
-	var id: String? = null
-	var title: String? = null
-	var apiUrl: String? = null
-}
+class UrlLink (
+	val id: String? = null,
+	val title: String? = null,
+	val apiUrl: String? = null
+)

--- a/core/src/main/java/com/cube/fusion/core/model/action/EmailAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/EmailAction.kt
@@ -16,13 +16,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-class EmailAction : Action() {
-	val to: ArrayList<String>? = null
-	val cc: ArrayList<String>? = null
-	val bcc: ArrayList<String>? = null
-	val subject: String? = null
+class EmailAction(
+	val to: ArrayList<String>? = null,
+	val cc: ArrayList<String>? = null,
+	val bcc: ArrayList<String>? = null,
+	val subject: String? = null,
 	val body: String? = null
-
+) : Action() {
 	override fun extractClick(): String? {
 		return null
 	}

--- a/core/src/main/java/com/cube/fusion/core/model/action/LinkAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/LinkAction.kt
@@ -16,9 +16,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class LinkAction : Action() {
-	var link: String? = null
+class LinkAction(
+	var link: String? = null,
 	var inApp: Boolean = false
+) : Action() {
 	override fun extractClick(): String? {
 		return link
 	}

--- a/core/src/main/java/com/cube/fusion/core/model/action/NativeAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/NativeAction.kt
@@ -18,7 +18,7 @@ import kotlinx.parcelize.Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Parcelize
 class NativeAction @JsonCreator
-constructor(@JsonProperty("link") var link: String?) : Action(), Parcelable {
+constructor(@JsonProperty("link") var link: String? = null) : Action(), Parcelable {
 	override fun extractClick(): String? {
 		return link
 	}

--- a/core/src/main/java/com/cube/fusion/core/model/action/PageAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/PageAction.kt
@@ -12,9 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
  * @property entry the link to the Fusion page entry to redirect to
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-class PageAction : Action() {
-	var entry: UrlLink? = null
-
+class PageAction(var entry: UrlLink? = null) : Action() {
 	override fun extractClick(): String? {
 		return entry?.apiUrl
 	}

--- a/core/src/main/java/com/cube/fusion/core/model/views/Bullet.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Bullet.kt
@@ -17,8 +17,8 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Bullet : Model(), Parcelable {
-	val title: Text? = null
-	val subtitle: Text? = null
+class Bullet(
+	val title: Text? = null,
+	val subtitle: Text? = null,
 	var order: Int = 0
-}
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/BulletGroup.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/BulletGroup.kt
@@ -15,6 +15,6 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
-class BulletGroup : Model(), Parcelable {
+class BulletGroup(
 	val children: ArrayList<Bullet> = ArrayList()
-}
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/Button.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Button.kt
@@ -10,6 +10,6 @@ import com.cube.fusion.core.model.action.Action
  *
  * @property action the action to handle when the button is pressed
  */
-class Button : Text() {
+class Button(
 	var action: Action? = null
-}
+) : Text()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Divider.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Divider.kt
@@ -18,6 +18,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Divider : Model(), Parcelable {
-	var strokeWidth: Float? = null
-}
+class Divider (
+	val strokeWidth: Float? = null
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a single image view
@@ -19,6 +20,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Image : Model(), Parcelable {
-	var src: ImageSource? = null
-}
+class Image (
+	val src: @RawValue ImageSource? = null
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a list item with optional start image, title and subtitle, and click action handling
@@ -22,9 +23,9 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class ListItem : Model(), Parcelable {
-	var image: Image? = null
-	var title: Text? = null
-	var subtitle: Text? = null
-	var action: Action? = null
-}
+class ListItem(
+	val image: Image? = null,
+	val title: Text? = null,
+	val subtitle: Text? = null,
+	val action: @RawValue Action? = null
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/Screen.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Screen.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 
 /**
  * Container model for a list of models to display in a single Fusion screen
@@ -18,6 +19,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Screen : Model(), Parcelable {
-	val children: MutableList<Model> = mutableListOf()
-}
+class Screen(
+	val children: @RawValue MutableList<Model> = mutableListOf()
+) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a single piece of text
@@ -27,23 +28,12 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-open class Text : Model(), Parcelable {
-	var textColor: String? = null
-
-	var content: String? = null
-
-	// `Font` style of the text
-	var font: Font? = null
-
-	// `TextAlignment`
-	var textAlignment: TextAlignment? = null
-
-	// Number of lines to show this text in
-	var numberOfLines: Int? = null
-
-	// Height of the line
-	var lineHeight: Float? = null
-
-	// Letter spacing
-	var letterSpacing: Float? = null
-}
+open class Text (
+	val textColor: String? = null,
+	val content: String? = null,
+	val font: @RawValue Font? = null,
+	val textAlignment: TextAlignment? = null,
+	val numberOfLines: Int? = null,
+	val lineHeight: Float? = null,
+	val letterSpacing: Float? = null
+)  : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
@@ -29,11 +29,11 @@ import kotlinx.parcelize.RawValue
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 open class Text (
-	val textColor: String? = null,
-	val content: String? = null,
-	val font: @RawValue Font? = null,
-	val textAlignment: TextAlignment? = null,
-	val numberOfLines: Int? = null,
-	val lineHeight: Float? = null,
-	val letterSpacing: Float? = null
+	var textColor: String? = null,
+	var content: String? = null,
+	var font: @RawValue Font? = null,
+	var textAlignment: TextAlignment? = null,
+	var numberOfLines: Int? = null,
+	var lineHeight: Float? = null,
+	var letterSpacing: Float? = null
 )  : Model(), Parcelable

--- a/core/src/test/java/com/cube/fusion/core/model/MarginJVMTests.kt
+++ b/core/src/test/java/com/cube/fusion/core/model/MarginJVMTests.kt
@@ -27,4 +27,13 @@ class MarginJVMTests {
 		MarginTestData.COMPLETE_MARGIN,
 		MarginTestData.COMPLETE_MARGIN_JSON
 	)
+
+	/**
+	 * Test that the relevant JSON data for a [Margin] instance with zero margin matches the zero margin method
+	 */
+	@Test
+	fun testZeroMarginDeserialisationEquality() = assertEqualityFromJsonDeserialisation(
+		Margin.zeroMargin(),
+		MarginTestData.ZERO_MARGIN_JSON
+	)
 }

--- a/core/src/test/java/com/cube/fusion/core/model/PaddingJVMTests.kt
+++ b/core/src/test/java/com/cube/fusion/core/model/PaddingJVMTests.kt
@@ -27,4 +27,13 @@ class PaddingJVMTests {
 		PaddingTestData.COMPLETE_PADDING,
 		PaddingTestData.COMPLETE_PADDING_JSON
 	)
+	
+	/**
+	 * Test that the relevant JSON data for a [Padding] instance with zero margin matches the zero margin method
+	 */
+	@Test
+	fun testZeroPaddingDeserialisationEquality() = assertEqualityFromJsonDeserialisation(
+		Padding.zeroPadding(),
+		PaddingTestData.ZERO_PADDING_JSON
+	)
 }

--- a/core/src/test/java/com/cube/fusion/core/model/action/NativeActionJVMTests.kt
+++ b/core/src/test/java/com/cube/fusion/core/model/action/NativeActionJVMTests.kt
@@ -15,7 +15,7 @@ class NativeActionJVMTests {
 	 */
 	@Test
 	fun testNoArgsNativeActionDeserialisationEquality() = assertEqualityFromJsonDeserialisation(
-		NativeAction(null), // TODO: class needs a no-args constructor
+		NativeAction(),
 		NativeActionTestData.NO_ARGS_NATIVE_ACTION_JSON
 	)
 

--- a/sharedtest/src/main/java/com/cube/fusion/core/extensions/StringExtensions.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/extensions/StringExtensions.kt
@@ -11,4 +11,9 @@ object StringExtensions {
 	 * Trims the outer curly brackets and any whitespace from this JSON-formatted [String]
 	 */
 	fun String.trimJsonContainer() = this.trimStart(' ', '\t', '\n', '{').trimEnd(' ', '\t', '\n').trimEnd('}')
+
+	/**
+	 * Removes the class from this JSON-formatted [String]
+	 */
+	fun String.withoutClass() = this.replace(Regex("\"class\": \"[a-zA-Z]+\","), "")
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/BorderTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/BorderTestData.kt
@@ -27,6 +27,7 @@ object BorderTestData {
 	 * An instance of [Border] expected to match the parsed value of [COMPLETE_BORDER_JSON]
 	 */
 	val COMPLETE_BORDER = Border(
-		// TODO: Update Border with a non-default constructor
+		strokeWidth = 2.4f,
+		color = "#CCEEFF"
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/FontTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/FontTestData.kt
@@ -28,6 +28,8 @@ object FontTestData {
 	 * An instance of [Font] expected to match the parsed value of [COMPLETE_FONT_JSON]
 	 */
 	val COMPLETE_FONT = Font(
-		// TODO: Update Font with a non-default constructor
+		name = "Open Sans",
+		weight = Font.Weight.REGULAR,
+		size = 22f
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/ImageSourceTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/ImageSourceTestData.kt
@@ -29,6 +29,9 @@ object ImageSourceTestData {
 	 * An instance of [ImageSource] expected to match the parsed value of [COMPLETE_IMAGE_SOURCE_JSON]
 	 */
 	val COMPLETE_IMAGE_SOURCE = ImageSource(
-		// TODO: Update ImageSource with a non-default constructor
+		url = "image_url",
+		id = "src_id",
+		permalink = "permalink_url",
+		apiUrl = "src_url"
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/MarginTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/MarginTestData.kt
@@ -26,6 +26,18 @@ object MarginTestData {
 	""".trimIndent()
 
 	/**
+	 * The JSON data expected to parse to [Margin.zeroMargin]
+	 */
+	val ZERO_MARGIN_JSON = """
+		{
+			"left": 0,
+			"top": 0,
+			"right": 0,
+			"bottom": 0
+		}
+	""".trimIndent()
+
+	/**
 	 * An instance of [Margin] expected to match the parsed value of [COMPLETE_MARGIN_JSON]
 	 */
 	val COMPLETE_MARGIN = Margin(

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/MarginTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/MarginTestData.kt
@@ -21,7 +21,7 @@ object MarginTestData {
 			"left": 30,
 			"top": 2.63,
 			"right": 500,
-			"bottom": 1234.5678
+			"bottom": 1234.5677
 		}
 	""".trimIndent()
 
@@ -29,6 +29,9 @@ object MarginTestData {
 	 * An instance of [Margin] expected to match the parsed value of [COMPLETE_MARGIN_JSON]
 	 */
 	val COMPLETE_MARGIN = Margin(
-		// TODO: Update Margin with a non-default constructor
+		left = 30f,
+		top = 2.63f,
+		right = 500f,
+		bottom = 1234.5677f
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/ModelTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/ModelTestData.kt
@@ -13,11 +13,24 @@ object ModelTestData {
 	val COMPLETE_MODEL_JSON = """
 		{
 			"background_color": "#FFEEDD",
-			"cornerRadius": 3.2,
+			"corner_radius": 3.2,
 			"padding": ${PaddingTestData.COMPLETE_PADDING_JSON},
 			"margin": ${MarginTestData.COMPLETE_MARGIN_JSON},
 			"border": ${BorderTestData.COMPLETE_BORDER_JSON},
 			"shadow": ${ShadowTestData.COMPLETE_SHADOW_JSON}
 		}
 	""".trimIndent()
+
+	/**
+	 * Temporary method for applying base model properties to a class that inherits model
+	 * TODO remove; rework to use encapsulation rather than inheritance for these properties
+	 */
+	inline fun <reified T : Model> T.withCompleteModelProperties() = apply {
+		backgroundColor = "#FFEEDD"
+		cornerRadius = 3.2f
+		padding = PaddingTestData.COMPLETE_PADDING
+		margin = MarginTestData.COMPLETE_MARGIN
+		border = BorderTestData.COMPLETE_BORDER
+		shadow = ShadowTestData.COMPLETE_SHADOW
+	}
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/PaddingTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/PaddingTestData.kt
@@ -26,6 +26,18 @@ object PaddingTestData {
 	""".trimIndent()
 
 	/**
+	 * The JSON data expected to parse to [Padding.zeroPadding]
+	 */
+	val ZERO_PADDING_JSON = """
+		{
+			"left": 0,
+			"top": 0,
+			"right": 0,
+			"bottom": 0
+		}
+	""".trimIndent()
+
+	/**
 	 * An instance of [Padding] expected to match the parsed value of [COMPLETE_PADDING_JSON]
 	 */
 	val COMPLETE_PADDING = Padding(

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/PaddingTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/PaddingTestData.kt
@@ -21,7 +21,7 @@ object PaddingTestData {
 			"left": 31,
 			"top": 3.63,
 			"right": 600,
-			"bottom": 2234.5678
+			"bottom": 2234.5679
 		}
 	""".trimIndent()
 
@@ -29,6 +29,9 @@ object PaddingTestData {
 	 * An instance of [Padding] expected to match the parsed value of [COMPLETE_PADDING_JSON]
 	 */
 	val COMPLETE_PADDING = Padding(
-		// TODO: Update Padding with a non-default constructor
+		left = 31f,
+		top = 3.63f,
+		right = 600f,
+		bottom = 2234.5679f
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/PageTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/PageTestData.kt
@@ -43,7 +43,11 @@ object PageTestData {
 	 * An instance of [Page] expected to match the parsed value of [COMPLETE_PAGE_JSON]
 	 */
 	val COMPLETE_PAGE = Page(
-		// TODO: Update Page with a non-default constructor
+		id = "page_id",
+		slug = "page_slug",
+		title = "page_title",
+		analyticsScreenView = "page_analytics_screen_view",
+		screen = ScreenTestData.COMPLETE_SCREEN
 	)
 
 	/**

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/ShadowTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/ShadowTestData.kt
@@ -31,6 +31,11 @@ object ShadowTestData {
 	 * An instance of [Shadow] expected to match the parsed value of [COMPLETE_SHADOW_JSON]
 	 */
 	val COMPLETE_SHADOW = Shadow(
-		// TODO: Update Shadow with a non-default constructor
+		color = "#FFCC00",
+		alpha = 0.78f,
+		x = 9.9f,
+		y = 1.7f,
+		blur = 3.2f,
+		spread = 0.5f
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/SizeTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/SizeTestData.kt
@@ -27,6 +27,7 @@ object SizeTestData {
 	 * An instance of [Size] expected to match the parsed value of [COMPLETE_SIZE_JSON]
 	 */
 	val COMPLETE_SIZE = Size(
-		// TODO: Update Size with a non-default constructor
+		width = 36.2f,
+		height = 75.1f
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/UrlLinkTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/UrlLinkTestData.kt
@@ -20,7 +20,7 @@ object UrlLinkTestData {
 		{
 			"id": "page_id",
 			"title": "My Page",
-			"apiUrl": "page_url"
+			"api_url": "page_url"
 		}
 	""".trimIndent()
 
@@ -28,6 +28,8 @@ object UrlLinkTestData {
 	 * An instance of [UrlLink] expected to match the parsed value of [COMPLETE_URL_LINK_JSON]
 	 */
 	val COMPLETE_URL_LINK = UrlLink(
-		// TODO: Update UrlLink with a non-default constructor
+		id = "page_id",
+		title = "My Page",
+		apiUrl = "page_url"
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/action/EmailActionTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/action/EmailActionTestData.kt
@@ -35,6 +35,10 @@ object EmailActionTestData {
 	 * An instance of [EmailAction] expected to match the parsed value of [COMPLETE_EMAIL_ACTION_JSON]
 	 */
 	val COMPLETE_EMAIL_ACTION = EmailAction(
-		// TODO: Update EmailAction with a non-default constructor
+		to = arrayListOf("fake1@email.com", "fake2@email.com"),
+		cc = arrayListOf("fake3@email.com", "fake4@email.com"),
+		bcc = arrayListOf("fake5@email.com", "fake6@email.com"),
+		subject = "Email Subject",
+		body = "To whom it may concern,\nThis is a test\nYours sincerely,\nJR"
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/action/LinkActionTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/action/LinkActionTestData.kt
@@ -32,6 +32,7 @@ object LinkActionTestData {
 	 * An instance of [LinkAction] expected to match the parsed value of [COMPLETE_LINK_ACTION_JSON]
 	 */
 	val COMPLETE_LINK_ACTION = LinkAction(
-		// TODO: Update LinkAction with a non-default constructor
+		link = "www.google.com",
+		inApp = true
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/action/PageActionTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/action/PageActionTestData.kt
@@ -33,6 +33,6 @@ object PageActionTestData {
 	 * An instance of [PageAction] expected to match the parsed value of [COMPLETE_PAGE_ACTION_JSON]
 	 */
 	val COMPLETE_PAGE_ACTION = PageAction(
-		// TODO: Update PageAction with a non-default constructor
+		entry = UrlLinkTestData.COMPLETE_URL_LINK
 	)
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/BulletGroupTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/BulletGroupTestData.kt
@@ -3,8 +3,10 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.FontTestData
 import com.cube.fusion.core.model.ModelTestData
-import com.cube.fusion.core.resolver.ViewResolver
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
+import com.cube.fusion.core.model.TextAlignment
 import com.cube.fusion.core.resolver.TrivialViewResolver
+import com.cube.fusion.core.resolver.ViewResolver
 
 /**
  * Object containing useful data for [BulletGroup] test cases, for both JVM and instrumented tests
@@ -35,24 +37,24 @@ object BulletGroupTestData {
 					"class": "Bullet",
 					"title": {
 						"class": "Text",
-						"textColor": "#ADEECC",
+						"text_color": "#ADEECC",
 						"content": "BulletTitle2TextContent",
 						"font": ${FontTestData.COMPLETE_FONT_JSON},
-						"textAlignment": "right",
-						"numberOfLines": 81,
-						"lineHeight": 2.23,
-						"letterSpacing": 1.11,
+						"text_alignment": "right",
+						"number_of_lines": 81,
+						"line_height": 2.23,
+						"letter_spacing": 1.11,
 						${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 					},
 					"subtitle": {
 						"class": "Text",
-						"textColor": "#DDEECC",
+						"text_color": "#DDEECC",
 						"content": "BulletSubtitle2TextContent",
 						"font": ${FontTestData.COMPLETE_FONT_JSON},
-						"textAlignment": "justified",
-						"numberOfLines": 33,
-						"lineHeight": 7.19,
-						"letterSpacing": 92.88,
+						"text_alignment": "justified",
+						"number_of_lines": 33,
+						"line_height": 7.19,
+						"letter_spacing": 92.88,
 						${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 					},
 					"order": 32,
@@ -67,8 +69,31 @@ object BulletGroupTestData {
 	 * An instance of [BulletGroup] expected to match the parsed value of [COMPLETE_BULLET_GROUP_JSON]
 	 */
 	val COMPLETE_BULLET_GROUP = BulletGroup(
-		// TODO: Update BulletGroup with a non-default constructor
-	)
+		children = arrayListOf(
+			BulletTestData.COMPLETE_BULLET,
+			Bullet(
+				title = Text(
+					textColor = "#ADEECC",
+					content = "BulletTitle2TextContent",
+					font = FontTestData.COMPLETE_FONT,
+					textAlignment = TextAlignment.END,
+					numberOfLines = 81,
+					lineHeight = 2.23f,
+					letterSpacing = 1.11f,
+				).withCompleteModelProperties(),
+				subtitle = Text(
+					textColor = "#DDEECC",
+					content = "BulletSubtitle2TextContent",
+					font = FontTestData.COMPLETE_FONT,
+					textAlignment = TextAlignment.JUSTIFIED,
+					numberOfLines = 33,
+					lineHeight = 7.19f,
+					letterSpacing = 92.88f
+				).withCompleteModelProperties(),
+				order = 32
+			).withCompleteModelProperties()
+		)
+	).withCompleteModelProperties()
 
 	/**
 	 * The required view resolvers to deserialise [COMPLETE_BULLET_GROUP_JSON]

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/BulletTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/BulletTestData.kt
@@ -3,6 +3,8 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.FontTestData
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
+import com.cube.fusion.core.model.TextAlignment
 
 /**
  * Object containing useful data for [Bullet] test cases, for both JVM and instrumented tests
@@ -30,13 +32,13 @@ object BulletTestData {
 			"title": ${TextTestData.COMPLETE_TEXT_JSON},
 			"subtitle": {
 				"class": "Text",
-				"textColor": "#DDEECC",
+				"text_color": "#DDEECC",
 				"content": "BulletSubtitleTextContent",
 				"font": ${FontTestData.COMPLETE_FONT_JSON},
-				"textAlignment": "left",
-				"numberOfLines": 3,
-				"lineHeight": 7.1,
-				"letterSpacing": 9.88,
+				"text_alignment": "left",
+				"number_of_lines": 3,
+				"line_height": 7.1,
+				"letter_spacing": 9.88,
 				${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 			},
 			"order": 16,
@@ -48,6 +50,16 @@ object BulletTestData {
 	 * An instance of [Bullet] expected to match the parsed value of [COMPLETE_BULLET_JSON]
 	 */
 	val COMPLETE_BULLET = Bullet(
-		// TODO: Update Bullet with a non-default constructor
-	)
+		title = TextTestData.COMPLETE_TEXT,
+		subtitle = Text(
+			textColor = "#DDEECC",
+			content = "BulletSubtitleTextContent",
+			font = FontTestData.COMPLETE_FONT,
+			textAlignment = TextAlignment.START,
+			numberOfLines = 3,
+			lineHeight = 7.1f,
+			letterSpacing = 9.88f
+		).withCompleteModelProperties(),
+		order = 16
+	).withCompleteModelProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/ButtonTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/ButtonTestData.kt
@@ -1,7 +1,9 @@
 package com.cube.fusion.core.model.views
 
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
+import com.cube.fusion.core.extensions.StringExtensions.withoutClass
 import com.cube.fusion.core.model.action.LinkActionTestData
+import com.cube.fusion.core.model.views.TextTestData.withCompleteTextProperties
 
 /**
  * Object containing useful data for [Button] test cases, for both JVM and instrumented tests
@@ -27,7 +29,7 @@ object ButtonTestData {
 		{
 			"class": "Button",
 			"action": ${LinkActionTestData.COMPLETE_LINK_ACTION_JSON},
-			${TextTestData.COMPLETE_TEXT_JSON.trimJsonContainer()}
+			${TextTestData.COMPLETE_TEXT_JSON.trimJsonContainer().withoutClass()}
 		}
 	""".trimIndent()
 
@@ -35,6 +37,6 @@ object ButtonTestData {
 	 * An instance of [Button] expected to match the parsed value of [COMPLETE_BUTTON_JSON]
 	 */
 	val COMPLETE_BUTTON = Button(
-		// TODO: Update Button with a non-default constructor
-	)
+		action = LinkActionTestData.COMPLETE_LINK_ACTION
+	).withCompleteTextProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/DividerTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/DividerTestData.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.core.model.views
 
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
 
 /**
  * Object containing useful data for [Divider] test cases, for both JVM and instrumented tests
@@ -27,8 +28,6 @@ object DividerTestData {
 		{
 			"class": "Divider",
 			"stroke_width": "54.2",
-			"subtitle": "Divider Subtitle",
-			"order": 16,
 			${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 		}
 	""".trimIndent()
@@ -37,6 +36,6 @@ object DividerTestData {
 	 * An instance of [Divider] expected to match the parsed value of [COMPLETE_DIVIDER_JSON]
 	 */
 	val COMPLETE_DIVIDER = Divider(
-		// TODO: Update Divider with a non-default constructor
-	)
+		strokeWidth = 54.2f
+	).withCompleteModelProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/ImageTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/ImageTestData.kt
@@ -3,6 +3,7 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.ImageSourceTestData
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
 
 /**
  * Object containing useful data for [Image] test cases, for both JVM and instrumented tests
@@ -36,6 +37,6 @@ object ImageTestData {
 	 * An instance of [Image] expected to match the parsed value of [COMPLETE_IMAGE_JSON]
 	 */
 	val COMPLETE_IMAGE = Image(
-		// TODO: Update Image with a non-default constructor
-	)
+		src = ImageSourceTestData.COMPLETE_IMAGE_SOURCE
+	).withCompleteModelProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/ListItemTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/ListItemTestData.kt
@@ -3,6 +3,8 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.FontTestData
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
+import com.cube.fusion.core.model.TextAlignment
 import com.cube.fusion.core.model.action.EmailActionTestData
 
 /**
@@ -31,13 +33,13 @@ object ListItemTestData {
 			"title": ${TextTestData.COMPLETE_TEXT_JSON},
 			"subtitle": {
 				"class": "Text",
-				"textColor": "#DDEECC",
+				"text_color": "#DDEECC",
 				"content": "SubtitleTextContent",
 				"font": ${FontTestData.COMPLETE_FONT_JSON},
-				"textAlignment": "left",
-				"numberOfLines": 3,
-				"lineHeight": 7.1,
-				"letterSpacing": 9.88,
+				"text_alignment": "left",
+				"number_of_lines": 3,
+				"line_height": 7.1,
+				"letter_spacing": 9.88,
 				${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 			},
 			"image": ${ImageTestData.COMPLETE_IMAGE_JSON},
@@ -50,6 +52,17 @@ object ListItemTestData {
 	 * An instance of [ListItem] expected to match the parsed value of [COMPLETE_LIST_ITEM_JSON]
 	 */
 	val COMPLETE_LIST_ITEM = ListItem(
-		// TODO: Update ListItem with a non-default constructor
-	)
+		title = TextTestData.COMPLETE_TEXT,
+		subtitle = Text(
+			textColor = "#DDEECC",
+			content = "SubtitleTextContent",
+			font = FontTestData.COMPLETE_FONT,
+			textAlignment = TextAlignment.START,
+			numberOfLines = 3,
+			lineHeight = 7.1f,
+			letterSpacing = 9.88f
+		).withCompleteModelProperties(),
+		image = ImageTestData.COMPLETE_IMAGE,
+		action = EmailActionTestData.COMPLETE_EMAIL_ACTION
+	).withCompleteModelProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/ScreenTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/ScreenTestData.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.core.model.views
 
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
 import com.cube.fusion.core.resolver.TrivialViewResolver
 import com.cube.fusion.core.resolver.ViewResolver
 
@@ -45,8 +46,16 @@ object ScreenTestData {
 	 * An instance of [Screen] expected to match the parsed value of [COMPLETE_SCREEN_JSON]
 	 */
 	val COMPLETE_SCREEN = Screen(
-		// TODO: Update Screen with a non-default constructor
-	)
+		mutableListOf(
+			BulletGroupTestData.COMPLETE_BULLET_GROUP,
+			BulletTestData.COMPLETE_BULLET,
+			ButtonTestData.COMPLETE_BUTTON,
+			DividerTestData.COMPLETE_DIVIDER,
+			ImageTestData.COMPLETE_IMAGE,
+			ListItemTestData.COMPLETE_LIST_ITEM,
+			TextTestData.COMPLETE_TEXT
+		)
+	).withCompleteModelProperties()
 
 	/**
 	 * The required view resolvers to deserialise [COMPLETE_SCREEN_JSON]

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/TextTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/TextTestData.kt
@@ -3,6 +3,8 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.FontTestData
 import com.cube.fusion.core.model.ModelTestData
+import com.cube.fusion.core.model.ModelTestData.withCompleteModelProperties
+import com.cube.fusion.core.model.TextAlignment
 
 /**
  * Object containing useful data for [Text] test cases, for both JVM and instrumented tests
@@ -27,13 +29,13 @@ object TextTestData {
 	val COMPLETE_TEXT_JSON = """
 		{
 			"class": "Text",
-			"textColor": "#EEDDCC",
+			"text_color": "#EEDDCC",
 			"content": "TextContent",
 			"font": ${FontTestData.COMPLETE_FONT_JSON},
-			"textAlignment": "center",
-			"numberOfLines": 6,
-			"lineHeight": 5.2,
-			"letterSpacing": 3.33,
+			"text_alignment": "center",
+			"number_of_lines": 6,
+			"line_height": 5.2,
+			"letter_spacing": 3.33,
 			${ModelTestData.COMPLETE_MODEL_JSON.trimJsonContainer()}
 		}
 	""".trimIndent()
@@ -42,6 +44,12 @@ object TextTestData {
 	 * An instance of [Text] expected to match the parsed value of [COMPLETE_TEXT_JSON]
 	 */
 	val COMPLETE_TEXT = Text(
-		// TODO: Update Text with a non-default constructor
-	)
+		textColor = "#EEDDCC",
+		content = "TextContent",
+		font = FontTestData.COMPLETE_FONT,
+		textAlignment = TextAlignment.CENTER,
+		numberOfLines = 6,
+		lineHeight = 5.2f,
+		letterSpacing = 3.33f
+	).withCompleteModelProperties()
 }

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/TextTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/TextTestData.kt
@@ -52,4 +52,24 @@ object TextTestData {
 		lineHeight = 5.2f,
 		letterSpacing = 3.33f
 	).withCompleteModelProperties()
+
+	/**
+	 * Temporary method for applying base text properties to a class that inherits text
+	 * TODO remove; rework to use encapsulation rather than inheritance for these properties
+	 */
+	inline fun <reified T : Text> T.withCompleteTextProperties() = apply {
+		textColor = COMPLETE_TEXT.textColor
+		content = COMPLETE_TEXT.content
+		font = COMPLETE_TEXT.font
+		textAlignment = COMPLETE_TEXT.textAlignment
+		numberOfLines = COMPLETE_TEXT.numberOfLines
+		lineHeight = COMPLETE_TEXT.lineHeight
+		letterSpacing = COMPLETE_TEXT.letterSpacing
+		backgroundColor = COMPLETE_TEXT.backgroundColor
+		cornerRadius = COMPLETE_TEXT.cornerRadius
+		padding = COMPLETE_TEXT.padding
+		margin = COMPLETE_TEXT.margin
+		border = COMPLETE_TEXT.border
+		shadow = COMPLETE_TEXT.shadow
+	}
 }


### PR DESCRIPTION
### What?

- Reworks the Fusion model classes so that (mostly) member variables can be passed in the primary constructor, and are immutable
- Updates test data to use new primary constructors in order to match test requirements
- Adds a default argument to the `NativeAction.kt` default constructor
- Adds test cases for testing deserialisation for `Margin.zeroMargin()` and `Padding.zeroPadding()`
- Fixes issues with test data causing failing tests
    - Capitalisation issues with JSON data
    - Including class names from extended classes in JSON data
    - Not setting base class properties in extended classes

### Why?

This PR ensures that all JVM tests pass, and additionally enables the explicit construction of model classes, which may be used by library users in order to construct page data from sources other than JSON data.
It also increases the number of cases covered by the tests.
