### PR TITLE
:NORMAL: Feature/make models parcelable

### DIFF
--- a/core/src/main/java/com/cube/fusion/core/model/Border.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Border.kt
@@ -1,8 +1,10 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Class representing a solid border around a view
@@ -16,7 +18,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class Border(
 	var strokeWidth: Float = 0f,
 	var color: String? = null
-)
+): Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/Font.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Font.kt
@@ -1,9 +1,18 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
+import com.cube.fusion.core.model.Font.Weight
+import com.cube.fusion.core.model.Font.Weight.BOLD
+import com.cube.fusion.core.model.Font.Weight.HEAVY
+import com.cube.fusion.core.model.Font.Weight.ITALIC
+import com.cube.fusion.core.model.Font.Weight.LIGHT
+import com.cube.fusion.core.model.Font.Weight.REGULAR
+import com.cube.fusion.core.model.Font.Weight.SEMIBOLD
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Representation of a font specification in which to display a piece of text
@@ -17,11 +26,12 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class Font(
 	var name: String? = null,
 	var weight: Weight? = null,
 	var size: Float? = null
-) {
+) : Parcelable {
 	/**
 	 * Enum class representing different weights of font
 	 *

--- a/core/src/main/java/com/cube/fusion/core/model/ImageSource.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/ImageSource.kt
@@ -1,8 +1,10 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Representation of the source of an image that can be loaded into an appropriate view
@@ -17,9 +19,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class ImageSource(
 	var url: String? = null,
 	var id: String? = null,
 	var permalink: String? = null,
 	var apiUrl: String? = null
-)
+) : Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/Margin.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Margin.kt
@@ -1,8 +1,10 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Specification for the margin around a single Fusion view
@@ -17,12 +19,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class Margin(
 	val left: Float = 0.0f,
 	val top: Float = 0.0f,
 	val right: Float = 0.0f,
 	val bottom: Float = 0.0f
-) {
+) : Parcelable {
 
 	companion object {
 		/**

--- a/core/src/main/java/com/cube/fusion/core/model/Model.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Model.kt
@@ -1,5 +1,6 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -10,7 +11,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 	include = JsonTypeInfo.As.PROPERTY,
 	property = "class"
 )
-
 /**
  * Base class for all models for Fusion views
  * Contains all properties that most Fusion views should be able to configure their appearance with
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  * @property border the [Border] to display around the view
  * @property shadow the drop [Shadow] to display behind the view
  */
-abstract class Model {
+abstract class Model : Parcelable {
 	// Class of the view
 	open val `class`: String = javaClass.simpleName
 

--- a/core/src/main/java/com/cube/fusion/core/model/Padding.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Padding.kt
@@ -1,8 +1,10 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Specification for the padding inside a single Fusion view
@@ -17,12 +19,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class Padding(
 	val left: Float = 0.0f,
 	val top: Float = 0.0f,
 	val right: Float = 0.0f,
 	val bottom: Float = 0.0f
-) {
+) : Parcelable {
 
 	companion object {
 		/**

--- a/core/src/main/java/com/cube/fusion/core/model/Shadow.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/Shadow.kt
@@ -1,11 +1,14 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 /**
  * Class representing the drop shadow displayed behind a view
  *
@@ -27,4 +30,4 @@ class Shadow(
 	val y: Float = 0f,
 	val blur: Float = 0f,
 	val spread: Float = 0f
-)
+) : Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/UrlLink.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/UrlLink.kt
@@ -1,8 +1,10 @@
 package com.cube.fusion.core.model
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * Representation of a link to a Fusion page
@@ -17,8 +19,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class UrlLink (
 	val id: String? = null,
 	val title: String? = null,
 	val apiUrl: String? = null
-)
+) : Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/action/Action.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/Action.kt
@@ -1,7 +1,9 @@
 package com.cube.fusion.core.model.action
 
+import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import kotlinx.parcelize.IgnoredOnParcel
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "class")
 @JsonSubTypes(
@@ -18,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
  *
  * @property class the class name of the action - used for JSON parsing
  */
-abstract class Action {
-	open val `class`: String = javaClass.simpleName
+abstract class Action : Parcelable {
+	@IgnoredOnParcel open val `class`: String = javaClass.simpleName
 
 	abstract fun extractClick(): String?
 }

--- a/core/src/main/java/com/cube/fusion/core/model/action/EmailAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/EmailAction.kt
@@ -1,6 +1,7 @@
 package com.cube.fusion.core.model.action
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import kotlinx.parcelize.Parcelize
 
 /**
  * This class contains the data for an action that is handled as an email
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class EmailAction(
 	val to: ArrayList<String>? = null,
 	val cc: ArrayList<String>? = null,

--- a/core/src/main/java/com/cube/fusion/core/model/action/LinkAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/LinkAction.kt
@@ -3,6 +3,7 @@ package com.cube.fusion.core.model.action
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
+import kotlinx.parcelize.Parcelize
 
 /**
  * This class contains the data for an action that is handled by linking to a webpage
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class LinkAction(
 	var link: String? = null,
 	var inApp: Boolean = false

--- a/core/src/main/java/com/cube/fusion/core/model/action/NativeAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/NativeAction.kt
@@ -1,9 +1,7 @@
 package com.cube.fusion.core.model.action
 
 import android.os.Parcelable
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -17,8 +15,7 @@ import kotlinx.parcelize.Parcelize
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Parcelize
-class NativeAction @JsonCreator
-constructor(@JsonProperty("link") var link: String? = null) : Action(), Parcelable {
+class NativeAction(var link: String? = null) : Action(), Parcelable {
 	override fun extractClick(): String? {
 		return link
 	}

--- a/core/src/main/java/com/cube/fusion/core/model/action/PageAction.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/action/PageAction.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.core.model.action
 
 import com.cube.fusion.core.model.UrlLink
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import kotlinx.parcelize.Parcelize
 
 /**
  * This class contains the data of an action that is handled by redirecting to a new Fusion page
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
  * @property entry the link to the Fusion page entry to redirect to
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Parcelize
 class PageAction(var entry: UrlLink? = null) : Action() {
 	override fun extractClick(): String? {
 		return entry?.apiUrl

--- a/core/src/main/java/com/cube/fusion/core/model/views/Bullet.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Bullet.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import kotlinx.parcelize.Parcelize
@@ -21,4 +20,4 @@ class Bullet(
 	val title: Text? = null,
 	val subtitle: Text? = null,
 	var order: Int = 0
-) : Model(), Parcelable
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/BulletGroup.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/BulletGroup.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import kotlinx.parcelize.Parcelize
@@ -17,4 +16,4 @@ import kotlinx.parcelize.Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 class BulletGroup(
 	val children: ArrayList<Bullet> = ArrayList()
-) : Model(), Parcelable
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Divider.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Divider.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
@@ -20,4 +19,4 @@ import kotlinx.parcelize.Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Divider (
 	val strokeWidth: Float? = null
-) : Model(), Parcelable
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.ImageSource
 import com.cube.fusion.core.model.Model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
@@ -21,4 +20,4 @@ import kotlinx.parcelize.Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Image (
 	val src: ImageSource? = null
-) : Model(), Parcelable
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a single image view
@@ -21,5 +20,5 @@ import kotlinx.parcelize.RawValue
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Image (
-	val src: @RawValue ImageSource? = null
+	val src: ImageSource? = null
 ) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a list item with optional start image, title and subtitle, and click action handling
@@ -27,5 +26,5 @@ class ListItem(
 	val image: Image? = null,
 	val title: Text? = null,
 	val subtitle: Text? = null,
-	val action: @RawValue Action? = null
+	val action: Action? = null
 ) : Model(), Parcelable

--- a/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/ListItem.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.action.Action
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
@@ -27,4 +26,4 @@ class ListItem(
 	val title: Text? = null,
 	val subtitle: Text? = null,
 	val action: Action? = null
-) : Model(), Parcelable
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Screen.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Screen.kt
@@ -1,12 +1,10 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Model
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
 /**
  * Container model for a list of models to display in a single Fusion screen
@@ -20,5 +18,5 @@ import kotlinx.parcelize.RawValue
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Screen(
-	val children: @RawValue MutableList<Model> = mutableListOf()
-) : Model(), Parcelable
+	val children: MutableList<Model> = mutableListOf()
+) : Model()

--- a/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
 /**
  * Model representing a single piece of text
@@ -31,7 +30,7 @@ import kotlinx.parcelize.RawValue
 open class Text (
 	var textColor: String? = null,
 	var content: String? = null,
-	var font: @RawValue Font? = null,
+	var font: Font? = null,
 	var textAlignment: TextAlignment? = null,
 	var numberOfLines: Int? = null,
 	var lineHeight: Float? = null,

--- a/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Text.kt
@@ -1,6 +1,5 @@
 package com.cube.fusion.core.model.views
 
-import android.os.Parcelable
 import com.cube.fusion.core.model.Font
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.TextAlignment
@@ -35,4 +34,4 @@ open class Text (
 	var numberOfLines: Int? = null,
 	var lineHeight: Float? = null,
 	var letterSpacing: Float? = null
-)  : Model(), Parcelable
+)  : Model()


### PR DESCRIPTION
### What?
Updates all models to implement `Parcelable` using the `@Parcelize` annotation
### Why?
So that models can be saved to saved instance state, or passed via intents, in parcelised form