### PR TITLE
Feature/image size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ static def thisOrJitpackVersion(requiredVersion) {
 
 ext {
 	// Do not remove the call to thisOrJitpackVersion - this ensures that versions for all generated artifacts are aligned.
-	fusionLibVersion = thisOrJitpackVersion('v0.0.3')
+	fusionLibVersion = thisOrJitpackVersion('v0.0.4-alpha1')
 }
 
 task clean(type: Delete) {

--- a/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
+++ b/core/src/main/java/com/cube/fusion/core/model/views/Image.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.core.model.views
 
 import com.cube.fusion.core.model.ImageSource
 import com.cube.fusion.core.model.Model
+import com.cube.fusion.core.model.Size
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
@@ -21,5 +22,6 @@ import kotlinx.parcelize.Parcelize
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Image (
 	val src: ImageSource? = null,
+	val fixedSize: Size? = null,
 	@field:JsonUnwrapped val baseProperties: BaseViewProperties = BaseViewProperties()
 ) : Model()

--- a/sharedtest/src/main/java/com/cube/fusion/core/model/views/ImageTestData.kt
+++ b/sharedtest/src/main/java/com/cube/fusion/core/model/views/ImageTestData.kt
@@ -3,6 +3,7 @@ package com.cube.fusion.core.model.views
 import com.cube.fusion.core.extensions.StringExtensions.tabIndented
 import com.cube.fusion.core.extensions.StringExtensions.trimJsonContainer
 import com.cube.fusion.core.model.ImageSourceTestData
+import com.cube.fusion.core.model.SizeTestData
 
 /**
  * Object containing useful data for [Image] test cases, for both JVM and instrumented tests
@@ -28,6 +29,7 @@ object ImageTestData {
 		{
 			"class": "Image",
 			"src": ${ImageSourceTestData.COMPLETE_IMAGE_SOURCE_JSON.tabIndented(3)},
+			"fixed_size": ${SizeTestData.COMPLETE_SIZE_JSON.tabIndented(3)},
 			${BaseViewPropertiesTestData.COMPLETE_BASE_VIEW_PROPERTIES_JSON.trimJsonContainer().tabIndented(2)}
 		}
 	""".trimIndent()
@@ -37,6 +39,7 @@ object ImageTestData {
 	 */
 	val COMPLETE_IMAGE = Image(
 		src = ImageSourceTestData.COMPLETE_IMAGE_SOURCE,
+		fixedSize = SizeTestData.COMPLETE_SIZE,
 		baseProperties = BaseViewPropertiesTestData.COMPLETE_BASE_VIEW_PROPERTIES
 	)
 }


### PR DESCRIPTION
### What?
- Adds the `fixedSize` property to the `Image` model class
- Updates tests to reflect this change

### Why?
So that images (e.g icons in `ListItem`s) can be set to a fixed size in density-independent pixels (dp)